### PR TITLE
Migrate Onfido go library to v3

### DIFF
--- a/applicant.go
+++ b/applicant.go
@@ -17,7 +17,7 @@ const (
 	IDNumberTypeSocialInsurance IDNumberType = "social_insurance"
 	IDNumberTypeTaxID           IDNumberType = "tax_id"
 	IDNumberTypeIdentityCard    IDNumberType = "identity_card"
-	IDNumberTypeDrivingLicense  IDNumberType = "driving_license"
+	IDNumberTypeDrivingLicense  IDNumberType = "driving_licence"
 )
 
 // IDNumber represents an ID number from the Onfido API
@@ -34,26 +34,17 @@ type Applicants struct {
 
 // Applicant represents an applicant from the Onfido API
 type Applicant struct {
-	ID                string     `json:"id,omitempty"`
-	CreatedAt         *time.Time `json:"created_at,omitempty"`
-	Sandbox           bool       `json:"sandbox,omitempty"`
-	Title             string     `json:"title,omitempty"`
-	FirstName         string     `json:"first_name,omitempty"`
-	LastName          string     `json:"last_name,omitempty"`
-	MiddleName        string     `json:"middle_name,omitempty"`
-	Email             string     `json:"email,omitempty"`
-	Gender            string     `json:"gender,omitempty"`
-	DOB               string     `json:"dob,omitempty"`
-	Telephone         string     `json:"telephone,omitempty"`
-	Mobile            string     `json:"mobile,omitempty"`
-	Country           string     `json:"country,omitempty"`
-	MothersMaidenName string     `json:"mothers_maiden_name,omitempty"`
-	PreviousLastName  string     `json:"previous_last_name,omitempty"`
-	Nationality       string     `json:"nationality,omitempty"`
-	CountryOfBirth    string     `json:"country_of_birth,omitempty"`
-	TownOfBirth       string     `json:"town_of_birth,omitempty"`
-	IDNumbers         []IDNumber `json:"id_numbers,omitempty"`
-	Addresses         []Address  `json:"addresses,omitempty"`
+	ID         string     `json:"id,omitempty"`
+	CreatedAt  *time.Time `json:"created_at,omitempty"`
+	Sandbox    bool       `json:"sandbox,omitempty"`
+	Title      string     `json:"title,omitempty"`
+	FirstName  string     `json:"first_name,omitempty"`
+	LastName   string     `json:"last_name,omitempty"`
+	MiddleName string     `json:"middle_name,omitempty"`
+	Email      string     `json:"email,omitempty"`
+	DOB        string     `json:"dob,omitempty"`
+	IDNumbers  []IDNumber `json:"id_numbers,omitempty"`
+	Address    Address    `json:"address,omitempty"`
 }
 
 // CreateApplicant creates a new applicant.

--- a/check.go
+++ b/check.go
@@ -18,9 +18,6 @@ type CheckResult string
 
 // Supported check types
 const (
-	CheckTypeExpress  CheckType = "express"
-	CheckTypeStandard CheckType = "standard"
-
 	CheckStatusInProgress        CheckStatus = "in_progress"
 	CheckStatusAwaitingApplicant CheckStatus = "awaiting_applicant"
 	CheckStatusComplete          CheckStatus = "complete"
@@ -34,32 +31,35 @@ const (
 
 // CheckRequest represents a check request to Onfido API
 type CheckRequest struct {
-	Type                    CheckType `json:"type"`
-	RedirectURI             string    `json:"redirect_uri,omitempty"`
-	Reports                 []*Report `json:"reports"`
-	Tags                    []string  `json:"tags,omitempty"`
-	SupressFormEmails       bool      `json:"suppress_form_emails,omitempty"`
-	Async                   bool      `json:"async,omitempty"`
-	ChargeApplicantForCheck bool      `json:"charge_applicant_for_check,omitempty"`
+	ApplicantID             string   `json:"applicant_id"`
+	ReportNames             []string `json:"report_names"`
+	RedirectURI             string   `json:"redirect_uri,omitempty"`
+	Tags                    []string `json:"tags,omitempty"`
+	SupressFormEmails       bool     `json:"suppress_form_emails,omitempty"`
+	Async                   bool     `json:"asynchronous,omitempty"`
+	ChargeApplicantForCheck bool     `json:"charge_applicant_for_check,omitempty"`
 	// Consider is used for Sandbox Testing of multiple report scenarios.
 	// see https://documentation.onfido.com/#sandbox-responses
-	Consider []ReportName `json:"consider,omitempty"`
+	Consider              []ReportName `json:"consider,omitempty"`
+	ApplicantProvidesData bool         `json:"applicant_provides_data"`
 }
 
 // Check represents a check in Onfido API
 type Check struct {
-	ID          string      `json:"id,omitempty"`
-	CreatedAt   *time.Time  `json:"created_at,omitempty"`
-	Href        string      `json:"href,omitempty"`
-	Type        CheckType   `json:"type,omitempty"`
-	Status      CheckStatus `json:"status,omitempty"`
-	Result      CheckResult `json:"result,omitempty"`
-	DownloadURI string      `json:"download_uri,omitempty"`
-	FormURI     string      `json:"form_uri,omitempty"`
-	RedirectURI string      `json:"redirect_uri,omitempty"`
-	ResultsURI  string      `json:"results_uri,omitempty"`
-	Reports     []*Report   `json:"reports,omitempty"`
-	Tags        []string    `json:"tags,omitempty"`
+	ID                    string      `json:"id,omitempty"`
+	CreatedAt             *time.Time  `json:"created_at,omitempty"`
+	Href                  string      `json:"href,omitempty"`
+	Type                  CheckType   `json:"type,omitempty"`
+	Status                CheckStatus `json:"status,omitempty"`
+	Result                CheckResult `json:"result,omitempty"`
+	DownloadURI           string      `json:"download_uri,omitempty"`
+	FormURI               string      `json:"form_uri,omitempty"`
+	RedirectURI           string      `json:"redirect_uri,omitempty"`
+	ResultsURI            string      `json:"results_uri,omitempty"`
+	Reports               []*Report   `json:"reports,omitempty"`
+	Tags                  []string    `json:"tags,omitempty"`
+	ApplicantID           string      `json:"applicant_id,omitempty"`
+	ApplicantProvidesData bool        `json:"applicant_provides_data"`
 }
 
 // CheckRetrieved represents a check in the Onfido API which has been retrieved.
@@ -67,18 +67,20 @@ type Check struct {
 // is just a string of Report IDs, not fully expanded Report objects.
 // See https://documentation.onfido.com/?shell#check-object (Shell)
 type CheckRetrieved struct {
-	ID          string      `json:"id,omitempty"`
-	CreatedAt   *time.Time  `json:"created_at,omitempty"`
-	Href        string      `json:"href,omitempty"`
-	Type        CheckType   `json:"type,omitempty"`
-	Status      CheckStatus `json:"status,omitempty"`
-	Result      CheckResult `json:"result,omitempty"`
-	DownloadURI string      `json:"download_uri,omitempty"`
-	FormURI     string      `json:"form_uri,omitempty"`
-	RedirectURI string      `json:"redirect_uri,omitempty"`
-	ResultsURI  string      `json:"results_uri,omitempty"`
-	Reports     []string    `json:"reports,omitempty"`
-	Tags        []string    `json:"tags,omitempty"`
+	ID                    string      `json:"id,omitempty"`
+	CreatedAt             *time.Time  `json:"created_at,omitempty"`
+	Href                  string      `json:"href,omitempty"`
+	Type                  CheckType   `json:"type,omitempty"`
+	Status                CheckStatus `json:"status,omitempty"`
+	Result                CheckResult `json:"result,omitempty"`
+	DownloadURI           string      `json:"download_uri,omitempty"`
+	FormURI               string      `json:"form_uri,omitempty"`
+	RedirectURI           string      `json:"redirect_uri,omitempty"`
+	ResultsURI            string      `json:"results_uri,omitempty"`
+	Reports               []string    `json:"report_ids,omitempty"`
+	Tags                  []string    `json:"tags,omitempty"`
+	ApplicantID           string      `json:"applicant_id,omitempty"`
+	ApplicantProvidesData bool        `json:"applicant_provides_data"`
 }
 
 // Checks represents a list of checks in Onfido API
@@ -88,13 +90,13 @@ type Checks struct {
 
 // CreateCheck creates a new check for the provided applicant.
 // see https://documentation.onfido.com/?shell#create-check
-func (c *client) CreateCheck(ctx context.Context, applicantID string, cr CheckRequest) (*Check, error) {
+func (c *client) CreateCheck(ctx context.Context, cr CheckRequest) (*Check, error) {
 	jsonStr, err := json.Marshal(cr)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := c.newRequest("POST", "/applicants/"+applicantID+"/checks", bytes.NewBuffer(jsonStr))
+	req, err := c.newRequest("POST", "/checks", bytes.NewBuffer(jsonStr))
 	if err != nil {
 		return nil, err
 	}
@@ -104,10 +106,10 @@ func (c *client) CreateCheck(ctx context.Context, applicantID string, cr CheckRe
 	return &resp, err
 }
 
-// GetCheck retrieves a check for the provided applicant by its ID.
+// GetCheck retrieves a check by its ID
 // see https://documentation.onfido.com/?shell#retrieve-check
-func (c *client) GetCheck(ctx context.Context, applicantID, id string) (*CheckRetrieved, error) {
-	req, err := c.newRequest("GET", "/applicants/"+applicantID+"/checks/"+id, nil)
+func (c *client) GetCheck(ctx context.Context, id string) (*CheckRetrieved, error) {
+	req, err := c.newRequest("GET", "/checks/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -117,19 +119,20 @@ func (c *client) GetCheck(ctx context.Context, applicantID, id string) (*CheckRe
 	return &resp, err
 }
 
-// GetCheckExpanded retrieves a check for the provided applicant by its ID, with
+// GetCheckExpanded retrieves a check by its ID, with
 // the Check's Reports expanded within the returned Check object.
 // see https://documentation.onfido.com/?shell#retrieve-check (Shell) but refer to the JSON
 // response object for https://documentation.onfido.com/?php#check-object (PHP) for the expanded contents.
-func (c *client) GetCheckExpanded(ctx context.Context, applicantID, id string) (*Check, error) {
+func (c *client) GetCheckExpanded(ctx context.Context, id string) (*Check, error) {
 	// Get the CheckRetrieved object. This only includes Report IDs, not the expanded Report objects.
-	chkRetrieved, err := c.GetCheck(ctx, applicantID, id)
+	chkRetrieved, err := c.GetCheck(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
 	// Build a regular Check object, this is what will be returned assuming there is no error.
 	check := Check{
+		ApplicantID: chkRetrieved.ApplicantID,
 		CreatedAt:   chkRetrieved.CreatedAt,
 		DownloadURI: chkRetrieved.DownloadURI,
 		FormURI:     chkRetrieved.FormURI,
@@ -147,7 +150,7 @@ func (c *client) GetCheckExpanded(ctx context.Context, applicantID, id string) (
 	// For each Report ID in the CheckRetrieved object, fetch (expand) the Report
 	// into the returned Check object.
 	for i, reportID := range chkRetrieved.Reports {
-		rep, err := c.GetReport(ctx, id, reportID)
+		rep, err := c.GetReport(ctx, reportID)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +200,7 @@ func (c *client) ListChecks(applicantID string) *CheckIter {
 
 	return &CheckIter{&iter{
 		c:       c,
-		nextURL: "/applicants/" + applicantID + "/checks",
+		nextURL: "/checks?applicant_id=" + applicantID,
 		handler: handler,
 	}}
 }

--- a/examples/applicant/main.go
+++ b/examples/applicant/main.go
@@ -21,16 +21,14 @@ func main() {
 		Email:     "rcrowe@example.co.uk",
 		FirstName: "Rob",
 		LastName:  "Crowe",
-		Addresses: []onfido.Address{
-			{
-				BuildingNumber: "18",
-				Street:         "Wind Corner",
-				Town:           "Crawley",
-				State:          "West Sussex",
-				Postcode:       "NW9 5AB",
-				Country:        "GBR",
-				StartDate:      "2018-02-10",
-			},
+		Address: onfido.Address{
+			BuildingNumber: "18",
+			Street:         "Wind Corner",
+			Town:           "Crawley",
+			State:          "West Sussex",
+			Postcode:       "NW9 5AB",
+			Country:        "GBR",
+			StartDate:      "2018-02-10",
 		},
 	})
 	if err != nil {

--- a/examples/check/main.go
+++ b/examples/check/main.go
@@ -22,32 +22,26 @@ func main() {
 		Email:     "rcrowe@example.co.uk",
 		FirstName: "Rob",
 		LastName:  "Crowe",
-		Addresses: []onfido.Address{
-			{
-				BuildingNumber: "18",
-				Street:         "Wind Corner",
-				Town:           "Crawley",
-				State:          "West Sussex",
-				Postcode:       "NW9 5AB",
-				Country:        "GBR",
-				StartDate:      "2018-02-10",
-			},
+		Address: onfido.Address{
+			BuildingNumber: "18",
+			Street:         "Wind Corner",
+			Town:           "Crawley",
+			State:          "West Sussex",
+			Postcode:       "NW9 5AB",
+			Country:        "GBR",
+			StartDate:      "2018-02-10",
 		},
 	})
 	if err != nil {
 		panic(err)
 	}
 
-	check, err := client.CreateCheck(ctx, applicant.ID, onfido.CheckRequest{
-		Type: onfido.CheckTypeStandard,
-		Reports: []*onfido.Report{
-			{
-				Name: onfido.ReportNameDocument,
-			},
-			{
-				Name:    onfido.ReportNameIdentity,
-				Variant: onfido.ReportVariantKYC,
-			},
+	check, err := client.CreateCheck(ctx, onfido.CheckRequest{
+		ApplicantID: applicant.ID,
+		ApplicantProvidesData: true,
+		ReportNames: []string{
+			string(onfido.ReportNameDocument),
+			string(onfido.ReportNameIdentityEnhanced),
 		},
 	})
 	if err != nil {

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -22,16 +22,14 @@ func main() {
 		Email:     "rcrowe@example.co.uk",
 		FirstName: "Rob",
 		LastName:  "Crowe",
-		Addresses: []onfido.Address{
-			{
-				BuildingNumber: "18",
-				Street:         "Wind Corner",
-				Town:           "Crawley",
-				State:          "West Sussex",
-				Postcode:       "NW9 5AB",
-				Country:        "GBR",
-				StartDate:      "2018-02-10",
-			},
+		Address: onfido.Address{
+			BuildingNumber: "18",
+			Street:         "Wind Corner",
+			Town:           "Crawley",
+			State:          "West Sussex",
+			Postcode:       "NW9 5AB",
+			Country:        "GBR",
+			StartDate:      "2018-02-10",
 		},
 	})
 	if err != nil {

--- a/examples/upload-document/main.go
+++ b/examples/upload-document/main.go
@@ -23,7 +23,8 @@ func main() {
 	}
 	defer doc.Close()
 
-	document, err := client.UploadDocument(ctx, applicantID, onfido.DocumentRequest{
+	document, err := client.UploadDocument(ctx, onfido.DocumentRequest{
+		ApplicantID: applicantID,
 		File: doc,
 		Type: onfido.DocumentTypeIDCard,
 		Side: onfido.DocumentSideFront,

--- a/onfido.go
+++ b/onfido.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,7 +19,7 @@ import (
 
 // Constants
 const (
-	ClientVersion   = "0.2.0"
+	ClientVersion   = "0.1.0"
 	DefaultEndpoint = "https://api.eu.onfido.com/v3.1"
 	TokenEnv        = "ONFIDO_TOKEN"
 )
@@ -186,6 +188,13 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, handleResponseErr(resp)
 	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read body: %w", err)
+	}
+
+	log.Println(string(body))
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {

--- a/onfido.go
+++ b/onfido.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -188,15 +186,6 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, handleResponseErr(resp)
 	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read body: %w", err)
-	}
-	resp.Body.Close()
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-
-	log.Println(string(body))
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {

--- a/onfido.go
+++ b/onfido.go
@@ -193,6 +193,8 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if err != nil {
 		return nil, fmt.Errorf("unable to read body: %w", err)
 	}
+	resp.Body.Close()
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	log.Println(string(body))
 

--- a/onfido.go
+++ b/onfido.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -16,8 +17,8 @@ import (
 
 // Constants
 const (
-	ClientVersion   = "0.1.0"
-	DefaultEndpoint = "https://api.onfido.com/v2"
+	ClientVersion   = "0.2.0"
+	DefaultEndpoint = "https://api.eu.onfido.com/v3.1"
 	TokenEnv        = "ONFIDO_TOKEN"
 )
 
@@ -25,22 +26,22 @@ type OnfidoClient interface {
 	SetHTTPClient(client HTTPRequester)
 	NewSdkTokenWeb(ctx context.Context, applicantID, referrer string) (*SdkToken, error)
 	NewSdkTokenMobile(ctx context.Context, applicantID, applicationID string) (*SdkToken, error)
-	GetReport(ctx context.Context, checkID, id string) (*Report, error)
-	ResumeReport(ctx context.Context, checkID, id string) error
-	CancelReport(ctx context.Context, checkID, id string) error
+	GetReport(ctx context.Context, id string) (*Report, error)
+	ResumeReport(ctx context.Context, id string) error
+	CancelReport(ctx context.Context, id string) error
 	ListReports(checkID string) *ReportIter
-	GetDocument(ctx context.Context, applicantID, id string) (*Document, error)
+	GetDocument(ctx context.Context, id string) (*Document, error)
 	ListDocuments(applicantID string) *DocumentIter
-	UploadDocument(ctx context.Context, applicantID string, dr DocumentRequest) (*Document, error)
+	UploadDocument(ctx context.Context, dr DocumentRequest) (*Document, error)
 	ListLivePhotos(applicantID string) *LivePhotoIter
 	CreateApplicant(ctx context.Context, a Applicant) (*Applicant, error)
 	DeleteApplicant(ctx context.Context, id string) error
 	GetApplicant(ctx context.Context, id string) (*Applicant, error)
 	ListApplicants() *ApplicantIter
 	UpdateApplicant(ctx context.Context, a Applicant) (*Applicant, error)
-	CreateCheck(ctx context.Context, applicantID string, cr CheckRequest) (*Check, error)
-	GetCheck(ctx context.Context, applicantID, id string) (*CheckRetrieved, error)
-	GetCheckExpanded(ctx context.Context, applicantID, id string) (*Check, error)
+	CreateCheck(ctx context.Context, cr CheckRequest) (*Check, error)
+	GetCheck(ctx context.Context, id string) (*CheckRetrieved, error)
+	GetCheckExpanded(ctx context.Context, id string) (*Check, error)
 	ResumeCheck(ctx context.Context, id string) (*Check, error)
 	ListChecks(applicantID string) *CheckIter
 	CreateWebhook(ctx context.Context, wr WebhookRefRequest) (*WebhookRef, error)
@@ -138,11 +139,25 @@ func (c *client) newRequest(method, uri string, body io.Reader) (*http.Request, 
 		uri = c.endpoint + uri
 	}
 
+	// Add in query params if they are present
+	var q url.Values
+	splitUri := strings.Split(uri, "?")
+	if len(splitUri) == 2 {
+		uri = splitUri[0]
+
+		var err error
+		q, err = url.ParseQuery(splitUri[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	req, err := http.NewRequest(method, uri, body)
 	if err != nil {
 		return nil, err
 	}
 
+	req.URL.RawQuery = q.Encode()
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "Go-Onfido/"+ClientVersion)
 	req.Header.Set("Authorization", "Token token="+c.token.String())

--- a/onfido_test.go
+++ b/onfido_test.go
@@ -97,7 +97,7 @@ func TestNewRequest_WithFullURL(t *testing.T) {
 }
 
 func TestNewRequest_WithPathUri(t *testing.T) {
-	expectedURL := "https://api.onfido.com/v2/applicants"
+	expectedURL := "https://api.eu.onfido.com/v3.1/applicants"
 	client := NewClient("123").(*client)
 	uris := []string{"/applicants", "applicants"}
 

--- a/report.go
+++ b/report.go
@@ -53,7 +53,6 @@ type Report struct {
 	Options    map[string]interface{} `json:"options,omitempty"`
 	Breakdown  Breakdowns             `json:"breakdown,omitempty"`
 	Properties Properties             `json:"properties,omitempty"`
-	Documents  []string               `json:"documents,omitempty"`
 	CheckID    string                 `json:"check_id,omitempty"`
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -44,7 +44,7 @@ type WebhookRequest struct {
 		Object       struct {
 			ID          string `json:"id"`
 			Status      string `json:"status"`
-			CompletedAt string `json:"completed_at"`
+			CompletedAt string `json:"completed_at_iso8601"`
 			Href        string `json:"href"`
 		} `json:"object"`
 	} `json:"payload"`

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -45,7 +45,7 @@ func TestValidateSignature_InvalidSignature(t *testing.T) {
 
 func TestValidateSignature_ValidSignature(t *testing.T) {
 	wh := webhook{Token: "abc123"}
-	err := wh.ValidateSignature([]byte("hello world"), "fcc98c5b4f306cfe6b5b8fcce03ddb33fc13ae6b")
+	err := wh.ValidateSignature([]byte("hello world"), "8c301acf7e955038b486de8f2a35f7f28bb5755fd1f77e1dbf9ef9e27713ad0d")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestParseFromRequest_ValidSignature(t *testing.T) {
 	req := &http.Request{
 		Header: make(map[string][]string),
 	}
-	req.Header.Add(WebhookSignatureHeader, "d2ef30601350308c1f1c25c5fbf359badb95cbfb")
+	req.Header.Add(WebhookSignatureHeader, "b469eabb36776543320fc09ed03451c34706daa3a730a561868ab2cc4399f8ec")
 	req.Body = ioutil.NopCloser(bytes.NewBuffer([]byte("{\"msg\": \"hello world\"}")))
 
 	wh := webhook{Token: "abc123"}


### PR DESCRIPTION
This PR adds in all the necessary changes and fixes the tests for the migration to v3. Our interface is not completely backwards compatible so we may have to make use of the semver versioning in Go modules (I'm not sure if we're doing this with tags currently).

Migration guide is found here: https://developers.onfido.com/guide/api-v2-to-v3-migration-guide