### PR TITLE
Fix report field in Check object

### DIFF
--- a/check.go
+++ b/check.go
@@ -77,7 +77,7 @@ type CheckRetrieved struct {
 	FormURI               string      `json:"form_uri,omitempty"`
 	RedirectURI           string      `json:"redirect_uri,omitempty"`
 	ResultsURI            string      `json:"results_uri,omitempty"`
-	Reports               []string    `json:"report_ids,omitempty"`
+	Reports               []string    `json:"reports,omitempty"`
 	Tags                  []string    `json:"tags,omitempty"`
 	ApplicantID           string      `json:"applicant_id,omitempty"`
 	ApplicantProvidesData bool        `json:"applicant_provides_data"`

--- a/onfido.go
+++ b/onfido.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -186,6 +188,15 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, handleResponseErr(resp)
 	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	log.Print(string(body))
+	resp.Body.Close()
+
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {

--- a/onfido.go
+++ b/onfido.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -188,15 +186,6 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, handleResponseErr(resp)
 	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	log.Print(string(body))
-	resp.Body.Close()
-
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {

--- a/report.go
+++ b/report.go
@@ -41,10 +41,6 @@ type ReportResult string
 // ReportSubResult represents a report sub result
 type ReportSubResult string
 
-type ReportDocumentOverview struct {
-	ID string `json:"id,omitempty"`
-}
-
 // Report represents a report from the Onfido API
 type Report struct {
 	ID         string                    `json:"id,omitempty"`
@@ -58,7 +54,6 @@ type Report struct {
 	Breakdown  Breakdowns                `json:"breakdown,omitempty"`
 	Properties Properties                `json:"properties,omitempty"`
 	CheckID    string                    `json:"check_id,omitempty"`
-	Documents  []*ReportDocumentOverview `json:"documents,omitempty"`
 }
 
 // Reports represents a list of reports from the Onfido API

--- a/report.go
+++ b/report.go
@@ -41,20 +41,24 @@ type ReportResult string
 // ReportSubResult represents a report sub result
 type ReportSubResult string
 
+type ReportDocumentOverview struct {
+	ID string `json:"id,omitempty"`
+}
+
 // Report represents a report from the Onfido API
 type Report struct {
-	ID         string                 `json:"id,omitempty"`
-	Name       ReportName             `json:"name,omitempty"`
-	CreatedAt  *time.Time             `json:"created_at,omitempty"`
-	Status     string                 `json:"status,omitempty"`
-	Result     ReportResult           `json:"result,omitempty"`
-	SubResult  ReportSubResult        `json:"sub_result,omitempty"`
-	Href       string                 `json:"href,omitempty"`
-	Options    map[string]interface{} `json:"options,omitempty"`
-	Breakdown  Breakdowns             `json:"breakdown,omitempty"`
-	Properties Properties             `json:"properties,omitempty"`
-	CheckID    string                 `json:"check_id,omitempty"`
-	Documents  map[string]interface{} `json:"documents,omitempty"`
+	ID         string                    `json:"id,omitempty"`
+	Name       ReportName                `json:"name,omitempty"`
+	CreatedAt  *time.Time                `json:"created_at,omitempty"`
+	Status     string                    `json:"status,omitempty"`
+	Result     ReportResult              `json:"result,omitempty"`
+	SubResult  ReportSubResult           `json:"sub_result,omitempty"`
+	Href       string                    `json:"href,omitempty"`
+	Options    map[string]interface{}    `json:"options,omitempty"`
+	Breakdown  Breakdowns                `json:"breakdown,omitempty"`
+	Properties Properties                `json:"properties,omitempty"`
+	CheckID    string                    `json:"check_id,omitempty"`
+	Documents  []*ReportDocumentOverview `json:"documents,omitempty"`
 }
 
 // Reports represents a list of reports from the Onfido API

--- a/report.go
+++ b/report.go
@@ -54,6 +54,7 @@ type Report struct {
 	Breakdown  Breakdowns             `json:"breakdown,omitempty"`
 	Properties Properties             `json:"properties,omitempty"`
 	CheckID    string                 `json:"check_id,omitempty"`
+	Documents  map[string]interface{} `json:"documents,omitempty"`
 }
 
 // Reports represents a list of reports from the Onfido API


### PR DESCRIPTION
Document Ids weren't being matched. In some of the API reference it talked about them as `report_ids` but in fact it is still reports... All tested on `staging` and working as expected.