### PR TITLE
Add download document and video methods

### DIFF
--- a/check.go
+++ b/check.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"log"
 	"time"
 )
 
@@ -130,8 +129,6 @@ func (c *client) GetCheckExpanded(ctx context.Context, id string) (*Check, error
 	if err != nil {
 		return nil, err
 	}
-
-	log.Println(chkRetrieved)
 
 	// Build a regular Check object, this is what will be returned assuming there is no error.
 	check := Check{

--- a/check.go
+++ b/check.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"time"
 )
 
@@ -77,7 +78,7 @@ type CheckRetrieved struct {
 	FormURI               string      `json:"form_uri,omitempty"`
 	RedirectURI           string      `json:"redirect_uri,omitempty"`
 	ResultsURI            string      `json:"results_uri,omitempty"`
-	Reports               []string    `json:"reports,omitempty"`
+	Reports               []string    `json:"report_ids,omitempty"`
 	Tags                  []string    `json:"tags,omitempty"`
 	ApplicantID           string      `json:"applicant_id,omitempty"`
 	ApplicantProvidesData bool        `json:"applicant_provides_data"`
@@ -129,6 +130,8 @@ func (c *client) GetCheckExpanded(ctx context.Context, id string) (*Check, error
 	if err != nil {
 		return nil, err
 	}
+
+	log.Println(chkRetrieved)
 
 	// Build a regular Check object, this is what will be returned assuming there is no error.
 	check := Check{

--- a/document.go
+++ b/document.go
@@ -143,6 +143,19 @@ func (c *client) GetDocument(ctx context.Context, id string) (*Document, error) 
 	return &resp, err
 }
 
+// DownloadDocument returns the binary data representing the document image
+// see https://documentation.onfido.com/#download-document
+func (c *client) DownloadDocument(ctx context.Context, id string) (*Document, error) {
+	req, err := c.newRequest("GET", "/documents/"+id+"/download", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp Document
+	_, err = c.do(ctx, req, &resp)
+	return &resp, err
+}
+
 // DocumentIter represents a document iterator
 type DocumentIter struct {
 	*iter

--- a/document.go
+++ b/document.go
@@ -3,6 +3,7 @@ package onfido
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,6 +55,11 @@ type Document struct {
 	Type         DocumentType `json:"type,omitempty"`
 	Side         DocumentSide `json:"side,omitempty"`
 	ApplicantID  string       `json:"applicant_id,omitempty"`
+}
+
+type DocumentDownload struct {
+	// Data is the binary data of the video encoded as a Base64 string
+	Data string
 }
 
 // Documents represents a list of documents from the Onfido API
@@ -145,15 +151,27 @@ func (c *client) GetDocument(ctx context.Context, id string) (*Document, error) 
 
 // DownloadDocument returns the binary data representing the document image
 // see https://documentation.onfido.com/#download-document
-func (c *client) DownloadDocument(ctx context.Context, id string) (*Document, error) {
+func (c *client) DownloadDocument(ctx context.Context, id string) (*DocumentDownload, error) {
 	req, err := c.newRequest("GET", "/documents/"+id+"/download", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var resp Document
+	var resp bytes.Buffer
 	_, err = c.do(ctx, req, &resp)
-	return &resp, err
+
+	var encodedBytes bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &encodedBytes)
+	defer encoder.Close()
+
+	_, err = encoder.Write(resp.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to write to encoded byte stream: %w", err)
+	}
+
+	return &DocumentDownload{
+		Data: encodedBytes.String(),
+	}, err
 }
 
 // DocumentIter represents a document iterator
@@ -184,7 +202,7 @@ func (c *client) ListDocuments(applicantID string) *DocumentIter {
 
 	return &DocumentIter{&iter{
 		c:       c,
-		nextURL: "/documents?applicant_id="+applicantID,
+		nextURL: "/documents?applicant_id=" + applicantID,
 		handler: handler,
 	}}
 }

--- a/live_videos.go
+++ b/live_videos.go
@@ -68,7 +68,7 @@ func (i *liveVideoIter) LiveVideo() *LiveVideo {
 
 // LiveVideoIter retrieves the list of live videos for the provided applicant.
 // see https://documentation.onfido.com/#list-live-videos
-func (c *client) ListLiveVideos(applicantID string) Iter {
+func (c *client) ListLiveVideos(applicantID string) LiveVideoIter {
 	return &liveVideoIter{&iter{
 		c:       c,
 		nextURL: "/live_videos?applicant_id=" + applicantID,

--- a/live_videos.go
+++ b/live_videos.go
@@ -52,20 +52,24 @@ func (c *client) DownloadLiveVideo(ctx context.Context, id string) (*LiveVideoDo
 	}, err
 }
 
-// LiveVideoIter represents a LiveVideo iterator
-type LiveVideoIter struct {
+// liveVideoIter represents a LiveVideo iterator
+type liveVideoIter struct {
 	*iter
 }
 
-// LiveVideo returns the current item in the iterator as a LiveVideo.
-func (i *LiveVideoIter) LiveVideo() *LiveVideo {
+type LiveVideoIter interface {
+	Iter
+	LiveVideo() *LiveVideo
+}
+
+func (i *liveVideoIter) LiveVideo() *LiveVideo {
 	return i.Current().(*LiveVideo)
 }
 
 // LiveVideoIter retrieves the list of live videos for the provided applicant.
 // see https://documentation.onfido.com/#list-live-videos
-func (c *client) ListLiveVideos(applicantID string) *LiveVideoIter {
-	return &LiveVideoIter{&iter{
+func (c *client) ListLiveVideos(applicantID string) Iter {
+	return &liveVideoIter{&iter{
 		c:       c,
 		nextURL: "/live_videos?applicant_id=" + applicantID,
 		handler: func(body []byte) ([]interface{}, error) {

--- a/live_videos.go
+++ b/live_videos.go
@@ -1,0 +1,33 @@
+package onfido
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// LiveVideo represents a live video object in Onfido API
+// https://documentation.onfido.com/#live-video-object
+type LiveVideo struct {
+	ID           string     `json:"id,omitempty"`
+	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	Href         string     `json:"href,omitempty"`
+	DownloadHref string     `json:"download_href,omitempty"`
+	FileName     string     `json:"file_name,omitempty"`
+	FileType     string     `json:"file_type,omitempty"`
+	FileSize     int        `json:"file_size,omitempty"`
+}
+
+// DownloadLiveVideo returns the binary data representing the video.
+// see https://documentation.onfido.com/#download-live-video
+func (c *client) DownloadLiveVideo(ctx context.Context, id string) (*LiveVideo, error) {
+	req, err := c.newRequest(http.MethodGet, "/live_videos/"+id+"/download", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp *LiveVideo
+	_, err = c.do(ctx, req, resp)
+
+	return resp, err
+}

--- a/live_videos_test.go
+++ b/live_videos_test.go
@@ -1,0 +1,36 @@
+package onfido
+
+import (
+	"context"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDownloadLiveVideo(t *testing.T) {
+	mockVideoID := "93672a37-8223-48b9-a440-3b5cb52a8e4b"
+	m := mux.NewRouter()
+	m.HandleFunc("/live_videos/{videoId}/download", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		assert.Equal(t, mockVideoID, vars["videoId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, wErr := w.Write([]byte("this is a video"))
+		assert.NoError(t, wErr)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := NewClient("123").(*client)
+	client.endpoint = srv.URL
+
+	videoDownload, err := client.DownloadLiveVideo(context.Background(), mockVideoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "dGhpcyBpcyBhIHZpZGVv", videoDownload.Data)
+}

--- a/live_videos_test.go
+++ b/live_videos_test.go
@@ -2,11 +2,13 @@ package onfido
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestDownloadLiveVideo(t *testing.T) {
@@ -33,4 +35,59 @@ func TestDownloadLiveVideo(t *testing.T) {
 	}
 
 	assert.Equal(t, "dGhpcyBpcyBhIHZpZGVv", videoDownload.Data)
+}
+
+func TestListLiveVideos(t *testing.T) {
+	applicantID := "541d040b-89f8-444b-8921-16b1333bf1c6"
+	createdAt := time.Now()
+
+	expected := LiveVideo{
+		ID:           "541d040b-89f8-444b-8921-16b1333bf1c7",
+		CreatedAt:    &createdAt,
+		Href:         "/v3.1/live_videos/7410A943-8F00-43D8-98DE-36A774196D86",
+		DownloadHref: "https://com/videos/pdf/1234",
+		FileName:     "something.mp4",
+		FileSize:     1234,
+		FileType:     "video/mp4",
+	}
+	expectedJSON, err := json.Marshal(struct {
+		LiveVideos []*LiveVideo `json:"live_videos"`
+	}{
+		LiveVideos: []*LiveVideo{&expected},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := mux.NewRouter()
+	m.HandleFunc("/live_videos", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("applicant_id") != applicantID {
+			t.Fatal("expected applicant id was not in the request")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, wErr := w.Write(expectedJSON)
+		assert.NoError(t, wErr)
+	}).Methods("GET")
+	srv := httptest.NewServer(m)
+	defer srv.Close()
+
+	client := NewClient("123").(*client)
+	client.endpoint = srv.URL
+
+	it := client.ListLiveVideos(applicantID)
+	for it.Next(context.Background()) {
+		c := it.LiveVideo()
+
+		assert.Equal(t, expected.ID, c.ID)
+		assert.True(t, expected.CreatedAt.Equal(*c.CreatedAt))
+		assert.Equal(t, expected.Href, c.Href)
+		assert.Equal(t, expected.DownloadHref, c.DownloadHref)
+		assert.Equal(t, expected.FileName, c.FileName)
+		assert.Equal(t, expected.FileSize, c.FileSize)
+		assert.Equal(t, expected.FileType, c.FileType)
+	}
+	if it.Err() != nil {
+		t.Fatal(it.Err())
+	}
 }

--- a/onfido.go
+++ b/onfido.go
@@ -36,6 +36,7 @@ type OnfidoClient interface {
 	DownloadDocument(ctx context.Context, id string) (*DocumentDownload, error)
 	ListLivePhotos(applicantID string) *LivePhotoIter
 	DownloadLiveVideo(ctx context.Context, id string) (*LiveVideoDownload, error)
+	ListLiveVideos(applicantID string) *LiveVideoIter
 	CreateApplicant(ctx context.Context, a Applicant) (*Applicant, error)
 	DeleteApplicant(ctx context.Context, id string) error
 	GetApplicant(ctx context.Context, id string) (*Applicant, error)

--- a/onfido.go
+++ b/onfido.go
@@ -221,6 +221,12 @@ func handleResponseErr(resp *http.Response) error {
 	return &onfidoErr
 }
 
+type Iter interface {
+	Current() interface{}
+	Err() error
+	Next(ctx context.Context) bool
+}
+
 type iter struct {
 	c       *client
 	nextURL string

--- a/onfido.go
+++ b/onfido.go
@@ -36,7 +36,7 @@ type OnfidoClient interface {
 	DownloadDocument(ctx context.Context, id string) (*DocumentDownload, error)
 	ListLivePhotos(applicantID string) *LivePhotoIter
 	DownloadLiveVideo(ctx context.Context, id string) (*LiveVideoDownload, error)
-	ListLiveVideos(applicantID string) *LiveVideoIter
+	ListLiveVideos(applicantID string) LiveVideoIter
 	CreateApplicant(ctx context.Context, a Applicant) (*Applicant, error)
 	DeleteApplicant(ctx context.Context, id string) error
 	GetApplicant(ctx context.Context, id string) (*Applicant, error)

--- a/onfido.go
+++ b/onfido.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,9 +33,9 @@ type OnfidoClient interface {
 	GetDocument(ctx context.Context, id string) (*Document, error)
 	ListDocuments(applicantID string) *DocumentIter
 	UploadDocument(ctx context.Context, dr DocumentRequest) (*Document, error)
-	DownloadDocument(ctx context.Context, id string) (*Document, error)
+	DownloadDocument(ctx context.Context, id string) (*DocumentDownload, error)
 	ListLivePhotos(applicantID string) *LivePhotoIter
-	DownloadLiveVideo(ctx context.Context, id string) (*LiveVideo, error)
+	DownloadLiveVideo(ctx context.Context, id string) (*LiveVideoDownload, error)
 	CreateApplicant(ctx context.Context, a Applicant) (*Applicant, error)
 	DeleteApplicant(ctx context.Context, id string) error
 	GetApplicant(ctx context.Context, id string) (*Applicant, error)
@@ -189,14 +188,6 @@ func (c *client) do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, handleResponseErr(resp)
 	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	resp.Body.Close()
-
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 	if v != nil {
 		if w, ok := v.(io.Writer); ok {

--- a/report.go
+++ b/report.go
@@ -41,19 +41,23 @@ type ReportResult string
 // ReportSubResult represents a report sub result
 type ReportSubResult string
 
+// DocumentProcessed contains metadata about the document that has been processed
+type DocumentProcessed map[string]interface{}
+
 // Report represents a report from the Onfido API
 type Report struct {
-	ID         string                    `json:"id,omitempty"`
-	Name       ReportName                `json:"name,omitempty"`
-	CreatedAt  *time.Time                `json:"created_at,omitempty"`
-	Status     string                    `json:"status,omitempty"`
-	Result     ReportResult              `json:"result,omitempty"`
-	SubResult  ReportSubResult           `json:"sub_result,omitempty"`
-	Href       string                    `json:"href,omitempty"`
-	Options    map[string]interface{}    `json:"options,omitempty"`
-	Breakdown  Breakdowns                `json:"breakdown,omitempty"`
-	Properties Properties                `json:"properties,omitempty"`
-	CheckID    string                    `json:"check_id,omitempty"`
+	ID         string                 `json:"id,omitempty"`
+	Name       ReportName             `json:"name,omitempty"`
+	CreatedAt  *time.Time             `json:"created_at,omitempty"`
+	Status     string                 `json:"status,omitempty"`
+	Result     ReportResult           `json:"result,omitempty"`
+	SubResult  ReportSubResult        `json:"sub_result,omitempty"`
+	Href       string                 `json:"href,omitempty"`
+	Options    map[string]interface{} `json:"options,omitempty"`
+	Breakdown  Breakdowns             `json:"breakdown,omitempty"`
+	Properties Properties             `json:"properties,omitempty"`
+	CheckID    string                 `json:"check_id,omitempty"`
+	Documents  []DocumentProcessed    `json:"documents,omitempty"`
 }
 
 // Reports represents a list of reports from the Onfido API


### PR DESCRIPTION
This PR adds the following:
- Download methods returning the binary data representing the image/video as a base64 encoded string
- Fix the field name for reports in the check
- Adds in the tested documents in the reports