### PR TITLE
Return downloads as binary data

### DIFF
--- a/document.go
+++ b/document.go
@@ -3,7 +3,6 @@ package onfido
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -58,8 +57,8 @@ type Document struct {
 }
 
 type DocumentDownload struct {
-	// Data is the binary data of the video encoded as a Base64 string
-	Data string
+	// Data is the binary data of the document
+	Data []byte
 }
 
 // Documents represents a list of documents from the Onfido API
@@ -159,18 +158,12 @@ func (c *client) DownloadDocument(ctx context.Context, id string) (*DocumentDown
 
 	var resp bytes.Buffer
 	_, err = c.do(ctx, req, &resp)
-
-	var encodedBytes bytes.Buffer
-	encoder := base64.NewEncoder(base64.StdEncoding, &encodedBytes)
-	defer encoder.Close()
-
-	_, err = encoder.Write(resp.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("failed to write to encoded byte stream: %w", err)
+		return nil, fmt.Errorf("failed to download document: %w", err)
 	}
 
 	return &DocumentDownload{
-		Data: encodedBytes.String(),
+		Data: resp.Bytes(),
 	}, err
 }
 

--- a/document_test.go
+++ b/document_test.go
@@ -247,5 +247,5 @@ func TestDownloadDocument(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "dGhpcyBpcyBhbiBpbWFn", documentDownload.Data)
+	assert.Equal(t, []byte("this is an image"), documentDownload.Data)
 }

--- a/live_videos.go
+++ b/live_videos.go
@@ -3,7 +3,6 @@ package onfido
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,8 +22,8 @@ type LiveVideo struct {
 }
 
 type LiveVideoDownload struct {
-	// Data is the binary data of the video encoded as a Base64 string
-	Data string
+	// Data is the binary data of the live video
+	Data []byte
 }
 
 // DownloadLiveVideo returns the binary data representing the video.
@@ -37,18 +36,11 @@ func (c *client) DownloadLiveVideo(ctx context.Context, id string) (*LiveVideoDo
 
 	var resp bytes.Buffer
 	_, err = c.do(ctx, req, &resp)
-
-	var encodedBytes bytes.Buffer
-	encoder := base64.NewEncoder(base64.StdEncoding, &encodedBytes)
-	defer encoder.Close()
-
-	_, err = encoder.Write(resp.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("failed to write to encoded byte stream: %w", err)
+		return nil, fmt.Errorf("failed to download live video: %w", err)
 	}
-
 	return &LiveVideoDownload{
-		Data: encodedBytes.String(),
+		Data: resp.Bytes(),
 	}, err
 }
 

--- a/live_videos_test.go
+++ b/live_videos_test.go
@@ -34,7 +34,7 @@ func TestDownloadLiveVideo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "dGhpcyBpcyBhIHZpZGVv", videoDownload.Data)
+	assert.Equal(t, []byte("this is a video"), videoDownload.Data)
 }
 
 func TestListLiveVideos(t *testing.T) {


### PR DESCRIPTION
In the previous PR I tried to be a little too smart and do the base64 encoding on the server. This is fine but it's unlikely to work with our `gRPC` messge sizes. By returning as binary data we can stream the data back to the client.