### PR TITLE
feat: add details to error message

### DIFF
--- a/onfido.go
+++ b/onfido.go
@@ -50,6 +50,9 @@ type ErrorFields map[string]interface{}
 
 func (e *Error) Error() string {
 	if e.Err.Msg != "" {
+		if len(e.Err.Fields) > 0 {
+			return fmt.Sprintf("%s: %q", e.Err.Msg, e.Err.Fields)
+		}
 		return e.Err.Msg
 	}
 	if e.Resp != nil {

--- a/onfido_test.go
+++ b/onfido_test.go
@@ -18,8 +18,15 @@ import (
 func TestError_MsgSet(t *testing.T) {
 	err := Error{}
 	err.Err.Msg = "some error message"
-	if err.Error() != err.Err.Msg {
-		t.Fatal()
+	if err.Error() != "some error message" {
+		t.Fatal(err.Error())
+	}
+
+	err = Error{}
+	err.Err.Msg = "some error message"
+	err.Err.Fields = ErrorFields{"key": []string{"value"}}
+	if err.Error() != "some error message: map[\"key\":[\"value\"]]" {
+		t.Fatal(err.Error())
 	}
 }
 


### PR DESCRIPTION
A validation error contains additional details in the `fields` field, which should be present in the string representation to aid debugging. 

```json
{
  "error": {
    "type": "validation_error",
    "message": "message",
    "fields": {
      "email": [
        "invalid format"
      ]
      "name": [
        "can't be blank"
      ]
    }
  }
}
```